### PR TITLE
Add @wext/shipit to "Tools" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Apps that help you manage your extensions.
 - [unzip-crx](https://github.com/peerigon/unzip-crx) - Unzips Google Chrome (crx) files.
 - [chrome-store-api](https://github.com/acvetkov/chrome-store-api) - Chrome Web Store API wrapper.
 - [Chrome extension source viewer](https://github.com/Rob--W/crxviewer) - WebExtension to view source code of extensions directly on the store.
+- [@wext/shipit](https://github.com/LinusU/wext-shipit) - Tool to automatically publish to Goole Webstore, Mozilla Addons and Opera Addons.
 
 ## Testing
 


### PR DESCRIPTION
[@wext/shipit](https://github.com/LinusU/wext-shipit) is a tool to automatically publish to Goole Webstore, Mozilla Addons and Opera Addons.

Safari Extensions and Extensions for Microsoft Edge will hopefully be supported soon as well :rocket: