### PR TITLE
Fix a minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Apps that help you manage your extensions.
 - [unzip-crx](https://github.com/peerigon/unzip-crx) - Unzips Google Chrome (crx) files.
 - [chrome-store-api](https://github.com/acvetkov/chrome-store-api) - Chrome Web Store API wrapper.
 - [Chrome extension source viewer](https://github.com/Rob--W/crxviewer) - WebExtension to view source code of extensions directly on the store.
-- [@wext/shipit](https://github.com/LinusU/wext-shipit) - Tool to automatically publish to Goole Webstore, Mozilla Addons and Opera Addons.
+- [@wext/shipit](https://github.com/LinusU/wext-shipit) - Tool to automatically publish to Chrome Web Store, Mozilla Addons and Opera Addons.
 
 ## Testing
 


### PR DESCRIPTION
"Goole" -> "Google". (And then went ahead and renamed it to "Chrome Web Store", for consistency with other descriptions.)