### PR TITLE
Add extenshi

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ Apps that help you manage your extensions.
 - [webpack-extension-reloader](https://github.com/rubenspgcavalcante/webpack-extension-reloader) - A Webpack plugin to automatically reload browser extensions during development.
 - [webpack-target-webextension](https://github.com/awesome-webextension/webpack-target-webextension) - Adds code-splitting support to WebExtensions build with Webpack.
 - [Extension.js](https://github.com/cezaraugusto/extension.js) - Plug-and-play, zero-config, cross-browser extension development tool.
+- [extenshi](https://github.com/MaximStone/extenshi-io) - Pre-publish security scanner and cross-store publisher (CLI + GitHub Actions) that flags permission, policy and dependency risks before you ship to Chrome, Firefox and Edge.
 
 ## Testing
 


### PR DESCRIPTION
Adds **extenshi** to the **Tools** category.

A pre-publish security scanner and cross-store publisher for browser extensions — a CLI (and GitHub Actions step) that flags permission, policy and dependency risks before you submit to Chrome, Firefox and Edge. Sits alongside addons-linter / Chrome Webstore Upload in the dev workflow.

- Repo: https://github.com/MaximStone/extenshi-io
- npm: `npx @extenshi/cli@latest scan ./dist/extension.zip`

Follows the guidelines: GitHub repo link, added to the bottom of the category, sentence-case description ending with a period.