### PR TITLE
Add cws-gate to Testing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ Apps that help you manage your extensions.
 - [webextensions-api-fake](https://github.com/stoically/webextensions-api-fake) - In-memory WebExtensions API Fake Implementation (includes TypeScript types).
 - [webextensions-api-mock](https://github.com/stoically/webextensions-api-mock) - WebExtensions API as sinon stubs (includes TypeScript types).
 - [webextensions-schema](https://github.com/stoically/webextensions-schema) - Programmatically consume the WebExtensions Schema JSON files.
+- [cws-gate](https://github.com/mordiaky/cws-gate) - Scan a local unpacked Chrome extension for common Manifest V3 / Web Store submission issues, as a CLI or GitHub Action. Zero network access, zero dependencies.
 
 ## Boilerplates
 


### PR DESCRIPTION
Adds [cws-gate](https://github.com/mordiaky/cws-gate), a free CLI + GitHub Action that scans a local unpacked Chrome extension for common Manifest V3 / Web Store pre-submission issues (manifest validity, leftover MV2 keys, CSP violations, remote-script/importScripts detection, overly broad permissions, locale consistency — 16 checks). Zero network access, zero runtime dependencies; nothing about the scanned extension ever leaves the machine or CI runner. It's a new project (currently in a beta feedback cycle), so open to any feedback on the addition itself.