### PR TITLE
Add mv3-doctor to Testing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ Apps that help you manage your extensions.
 - [webextensions-api-fake](https://github.com/stoically/webextensions-api-fake) - In-memory WebExtensions API Fake Implementation (includes TypeScript types).
 - [webextensions-api-mock](https://github.com/stoically/webextensions-api-mock) - WebExtensions API as sinon stubs (includes TypeScript types).
 - [webextensions-schema](https://github.com/stoically/webextensions-schema) - Programmatically consume the WebExtensions Schema JSON files.
+- [mv3-doctor](https://github.com/n0liu/mv3-doctor) - Diagnose Manifest V3 pitfalls (service-worker lifecycle, leftover MV2 keys, remote code, eval) in a built extension.
 
 ## Boilerplates
 


### PR DESCRIPTION
Adds [mv3-doctor](https://github.com/n0liu/mv3-doctor) to the Testing section.

It's a CLI that checks a built extension for Manifest V3 pitfalls: service-worker lifecycle bugs (timers that stop firing, DOM access, module state that resets on restart), leftover MV2 manifest keys, remote code loading, and eval. It reads `manifest.json` first to work out each script's role, so a rule only fires where it applies — `setInterval` is flagged in a service worker but not in a content script.

It sits naturally next to `addons-linter`: same idea (validate an extension), focused on the MV3-specific failure modes.

- Single addition, appended to the end of the Testing list.
- Description is capitalized and ends with a period.
- `npx awesome-lint` reports nothing on the added line.
