### PR TITLE
Add webext-ship-kit to Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ Apps that help you manage your extensions.
 - [webpack-extension-reloader](https://github.com/rubenspgcavalcante/webpack-extension-reloader) - A Webpack plugin to automatically reload browser extensions during development.
 - [webpack-target-webextension](https://github.com/awesome-webextension/webpack-target-webextension) - Adds code-splitting support to WebExtensions build with Webpack.
 - [Extension.js](https://github.com/cezaraugusto/extension.js) - Plug-and-play, zero-config, cross-browser extension development tool.
+- [webext-ship-kit](https://github.com/blueyferg/webext-ship-kit) - Build and pre-submission validation for shipping one Manifest V3 extension to Chrome, Edge, and Firefox.
 
 ## Testing
 


### PR DESCRIPTION
Adds a tool for building and pre-submission validation when shipping one Manifest V3 extension to Chrome, Edge, and Firefox from a single source tree. MIT licensed, no dependencies.